### PR TITLE
feat: Organization 支持 + namespace 权限隔离

### DIFF
--- a/src/commands/org.ts
+++ b/src/commands/org.ts
@@ -34,8 +34,8 @@ export function orgCommand(program: Command): void {
   org
     .command('create <name>')
     .description('Create a new organization')
-    .option('-d, --display-name <name>', 'Display name for the organization')
-    .action(async (name: string, opts: { displayName?: string }) => {
+    .option('-n, --name <name>', 'Display name for the organization')
+    .action(async (slug: string, opts: { name?: string }) => {
       const { token, baseUrl } = requireAuth();
       const spinner = ora('Creating organization...').start();
 
@@ -44,14 +44,14 @@ export function orgCommand(program: Command): void {
           method: 'POST',
           headers: authHeaders(token),
           body: JSON.stringify({
-            slug: name,
-            displayName: opts.displayName || name,
+            slug,
+            name: opts.name || slug,
           }),
         });
 
         const data = (await res.json()) as {
           success: boolean;
-          data?: { id: string; slug: string; displayName: string };
+          data?: { id: string; slug: string; name: string };
           error?: string;
         };
 
@@ -92,7 +92,7 @@ export function orgCommand(program: Command): void {
 
         const data = (await res.json()) as {
           success: boolean;
-          data?: Array<{ id: string; slug: string; displayName: string; role: string }>;
+          data?: Array<{ id: string; slug: string; name: string; role: string }>;
           error?: string;
         };
 
@@ -114,7 +114,7 @@ export function orgCommand(program: Command): void {
         for (const o of orgs) {
           const marker = o.slug === currentOrg ? chalk.green(' ← current') : '';
           console.log(`  ${chalk.bold(o.slug)}${marker}`);
-          console.log(chalk.gray(`    Name: ${o.displayName}  Role: ${o.role}`));
+          console.log(chalk.gray(`    Name: ${o.name}  Role: ${o.role}`));
         }
       } catch (err) {
         spinner.stop();
@@ -141,7 +141,7 @@ export function orgCommand(program: Command): void {
 
         const data = (await res.json()) as {
           success: boolean;
-          data?: { id: string; slug: string; displayName: string };
+          data?: { id: string; slug: string; name: string };
           error?: string;
         };
 

--- a/src/commands/org.ts
+++ b/src/commands/org.ts
@@ -1,0 +1,240 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import ora from 'ora';
+import {
+  getCredential,
+  getAuthBaseUrl,
+  getCurrentOrg,
+  setCurrentOrg,
+} from '@/utils/credentials';
+
+function requireAuth(): { token: string; baseUrl: string } {
+  const token = getCredential();
+  if (!token) {
+    console.error(chalk.red('❌ Not authenticated. Run `envx login` first.'));
+    process.exit(1);
+  }
+  return { token, baseUrl: getAuthBaseUrl() };
+}
+
+function authHeaders(token: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${token}`,
+    'Content-Type': 'application/json',
+    'User-Agent': '@leaperone/envx',
+  };
+}
+
+export function orgCommand(program: Command): void {
+  const org = program
+    .command('org')
+    .description('Manage organizations');
+
+  // envx org create <name>
+  org
+    .command('create <name>')
+    .description('Create a new organization')
+    .option('-d, --display-name <name>', 'Display name for the organization')
+    .action(async (name: string, opts: { displayName?: string }) => {
+      const { token, baseUrl } = requireAuth();
+      const spinner = ora('Creating organization...').start();
+
+      try {
+        const res = await fetch(new URL('/api/v1/cli/orgs', baseUrl).toString(), {
+          method: 'POST',
+          headers: authHeaders(token),
+          body: JSON.stringify({
+            slug: name,
+            displayName: opts.displayName || name,
+          }),
+        });
+
+        const data = (await res.json()) as {
+          success: boolean;
+          data?: { id: string; slug: string; displayName: string };
+          error?: string;
+        };
+
+        spinner.stop();
+
+        if (!res.ok || !data.success) {
+          console.error(chalk.red(`❌ Failed to create organization: ${data.error || res.statusText}`));
+          process.exit(1);
+        }
+
+        console.log(chalk.green(`✅ Organization "${data.data!.slug}" created successfully`));
+        console.log(chalk.gray(`   ID: ${data.data!.id}`));
+
+        // Auto-switch to the new org
+        setCurrentOrg(data.data!.slug);
+        console.log(chalk.blue(`🔄 Switched to organization "${data.data!.slug}"`));
+      } catch (err) {
+        spinner.stop();
+        console.error(chalk.red(`❌ Error: ${(err as Error).message}`));
+        process.exit(1);
+      }
+    });
+
+  // envx org list
+  org
+    .command('list')
+    .alias('ls')
+    .description('List organizations you belong to')
+    .action(async () => {
+      const { token, baseUrl } = requireAuth();
+      const spinner = ora('Fetching organizations...').start();
+
+      try {
+        const res = await fetch(new URL('/api/v1/cli/orgs', baseUrl).toString(), {
+          method: 'GET',
+          headers: authHeaders(token),
+        });
+
+        const data = (await res.json()) as {
+          success: boolean;
+          data?: Array<{ id: string; slug: string; displayName: string; role: string }>;
+          error?: string;
+        };
+
+        spinner.stop();
+
+        if (!res.ok || !data.success) {
+          console.error(chalk.red(`❌ Failed to list organizations: ${data.error || res.statusText}`));
+          process.exit(1);
+        }
+
+        const orgs = data.data || [];
+        if (orgs.length === 0) {
+          console.log(chalk.yellow('No organizations found. Create one with `envx org create <name>`.'));
+          return;
+        }
+
+        const currentOrg = getCurrentOrg();
+        console.log(chalk.blue('Organizations:\n'));
+        for (const o of orgs) {
+          const marker = o.slug === currentOrg ? chalk.green(' ← current') : '';
+          console.log(`  ${chalk.bold(o.slug)}${marker}`);
+          console.log(chalk.gray(`    Name: ${o.displayName}  Role: ${o.role}`));
+        }
+      } catch (err) {
+        spinner.stop();
+        console.error(chalk.red(`❌ Error: ${(err as Error).message}`));
+        process.exit(1);
+      }
+    });
+
+  // envx org switch <slug>
+  org
+    .command('switch <slug>')
+    .description('Switch to a different organization context')
+    .action(async (slug: string) => {
+      const { token, baseUrl } = requireAuth();
+
+      // Verify the org exists and user has access
+      const spinner = ora('Verifying organization...').start();
+
+      try {
+        const res = await fetch(new URL(`/api/v1/cli/orgs/${encodeURIComponent(slug)}`, baseUrl).toString(), {
+          method: 'GET',
+          headers: authHeaders(token),
+        });
+
+        const data = (await res.json()) as {
+          success: boolean;
+          data?: { id: string; slug: string; displayName: string };
+          error?: string;
+        };
+
+        spinner.stop();
+
+        if (!res.ok || !data.success) {
+          if (res.status === 403) {
+            console.error(chalk.red(`❌ You don't have access to organization "${slug}".`));
+          } else if (res.status === 404) {
+            console.error(chalk.red(`❌ Organization "${slug}" not found.`));
+          } else {
+            console.error(chalk.red(`❌ Failed: ${data.error || res.statusText}`));
+          }
+          process.exit(1);
+        }
+
+        setCurrentOrg(slug);
+        console.log(chalk.green(`✅ Switched to organization "${slug}"`));
+      } catch (err) {
+        spinner.stop();
+        console.error(chalk.red(`❌ Error: ${(err as Error).message}`));
+        process.exit(1);
+      }
+    });
+
+  // envx org current
+  org
+    .command('current')
+    .description('Show current organization context')
+    .action(() => {
+      const currentOrg = getCurrentOrg();
+      if (currentOrg) {
+        console.log(`Current organization: ${chalk.bold(currentOrg)}`);
+      } else {
+        console.log(chalk.yellow('No organization selected. Use `envx org switch <slug>` to select one.'));
+      }
+    });
+
+  // envx org members [slug]
+  org
+    .command('members [slug]')
+    .description('List members of an organization (defaults to current org)')
+    .action(async (slug?: string) => {
+      const { token, baseUrl } = requireAuth();
+      const orgSlug = slug || getCurrentOrg();
+
+      if (!orgSlug) {
+        console.error(chalk.red('❌ No organization specified. Use `envx org switch <slug>` first, or provide the org slug.'));
+        process.exit(1);
+      }
+
+      const spinner = ora('Fetching members...').start();
+
+      try {
+        const res = await fetch(
+          new URL(`/api/v1/cli/orgs/${encodeURIComponent(orgSlug)}/members`, baseUrl).toString(),
+          {
+            method: 'GET',
+            headers: authHeaders(token),
+          }
+        );
+
+        const data = (await res.json()) as {
+          success: boolean;
+          data?: Array<{ id: string; name?: string; email?: string; role: string }>;
+          error?: string;
+        };
+
+        spinner.stop();
+
+        if (!res.ok || !data.success) {
+          if (res.status === 403) {
+            console.error(chalk.red(`❌ You don't have permission to view members of "${orgSlug}".`));
+          } else {
+            console.error(chalk.red(`❌ Failed: ${data.error || res.statusText}`));
+          }
+          process.exit(1);
+        }
+
+        const members = data.data || [];
+        if (members.length === 0) {
+          console.log(chalk.yellow('No members found.'));
+          return;
+        }
+
+        console.log(chalk.blue(`Members of "${orgSlug}":\n`));
+        for (const m of members) {
+          console.log(`  ${chalk.bold(m.name || m.email || m.id)} ${chalk.gray(`(${m.role})`)}`);
+        }
+      } catch (err) {
+        spinner.stop();
+        console.error(chalk.red(`❌ Error: ${(err as Error).message}`));
+        process.exit(1);
+      }
+    });
+}

--- a/src/commands/pull.ts
+++ b/src/commands/pull.ts
@@ -154,6 +154,10 @@ export function pullCommand(program: Command): void {
         if (!response.ok) {
           if (response.status === 401) {
             console.error(chalk.red('❌ Authentication failed. Run `envx login` to re-authenticate.'));
+          } else if (response.status === 403) {
+            console.error(chalk.red(`❌ Permission denied: You don't have access to namespace "${parsedUrl.namespace}".`));
+            console.error(chalk.yellow('💡 Tip: Check that you have pull permission, or ask the namespace owner to grant access.'));
+            console.error(chalk.yellow('💡 Tip: Use `envx org list` to see your organizations.'));
           } else {
             console.error(chalk.red(`❌ Error: Remote server returned ${response.status}`));
             console.error(chalk.red(`Message: ${responseData.msg || 'Unknown error'}`));

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -134,6 +134,10 @@ export function pushCommand(program: Command): void {
         if (!response.ok) {
           if (response.status === 401) {
             console.error(chalk.red('❌ Authentication failed. Run `envx login` to re-authenticate.'));
+          } else if (response.status === 403) {
+            console.error(chalk.red(`❌ Permission denied: You don't have access to namespace "${parsedUrl.namespace}".`));
+            console.error(chalk.yellow('💡 Tip: Check that you have push permission, or ask the namespace owner to grant access.'));
+            console.error(chalk.yellow('💡 Tip: Use `envx org list` to see your organizations.'));
           } else {
             console.error(chalk.red(`❌ Error: Remote server returned ${response.status}`));
             console.error(chalk.red(`Message: ${responseData.msg || 'Unknown error'}`));

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import { pullCommand } from './commands/pull.js';
 import { loginCommand } from './commands/login.js';
 import { logoutCommand } from './commands/logout.js';
 import { whoamiCommand } from './commands/whoami.js';
+import { orgCommand } from './commands/org.js';
 
 const require = createRequire(import.meta.url);
 const { version } = require('../package.json');
@@ -44,6 +45,7 @@ pullCommand(program);
 loginCommand(program);
 logoutCommand(program);
 whoamiCommand(program);
+orgCommand(program);
 
 // 默认命令
 program

--- a/src/utils/credentials.ts
+++ b/src/utils/credentials.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 interface Credentials {
   token?: string;
   baseUrl?: string;
+  currentOrg?: string;
 }
 
 const CREDENTIALS_DIR = path.join(os.homedir(), '.envx');
@@ -51,6 +52,20 @@ export function getCredential(): string | undefined {
 
 export function getAuthBaseUrl(): string {
   return process.env.ENVX_BASEURL || loadCredentials().baseUrl || 'https://leaper.one';
+}
+
+export function getCurrentOrg(): string | undefined {
+  return loadCredentials().currentOrg;
+}
+
+export function setCurrentOrg(org: string | undefined): void {
+  const credentials = loadCredentials();
+  if (org) {
+    credentials.currentOrg = org;
+  } else {
+    delete credentials.currentOrg;
+  }
+  saveCredentials(credentials);
 }
 
 export { CREDENTIALS_DIR, CREDENTIALS_FILE };


### PR DESCRIPTION
## Summary
- **#6 Organization 支持**: 新增 `envx org` 命令组（create/list/switch/current/members），在 credentials 中持久化当前 org 上下文
- **#5 namespace 权限隔离**: push/pull 对 403 Forbidden 返回友好错误提示，引导用户检查权限或组织成员身份

### 新增命令
| 命令 | 说明 |
|------|------|
| `envx org create <name>` | 创建组织，可选 `--display-name` |
| `envx org list` / `envx org ls` | 列出所属组织 |
| `envx org switch <slug>` | 切换当前组织上下文 |
| `envx org current` | 显示当前选中的组织 |
| `envx org members [slug]` | 查看组织成员 |

### 权限错误示例
```
❌ Permission denied: You don't have access to namespace "acme".
💡 Tip: Check that you have push permission, or ask the namespace owner to grant access.
💡 Tip: Use `envx org list` to see your organizations.
```

Closes #6
Closes #5

## Test plan
- [ ] `envx org create test-org` 成功创建并自动切换
- [ ] `envx org list` 显示组织列表，标记当前组织
- [ ] `envx org switch` 切换上下文并持久化
- [ ] `envx org current` 显示当前组织
- [ ] `envx org members` 显示成员列表
- [ ] push/pull 对 403 显示友好权限错误
- [ ] 未认证时所有 org 命令提示先登录